### PR TITLE
Add strict-eval tool config and model_id CI input

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -33,6 +33,10 @@ on:
         description: Comma-separated pair of config IDs to compare (e.g. baseline,with-resolve-resource)
         required: false
         default: ""
+      model_id:
+        description: "Gemini model ID (e.g. gemini-3.1-flash-lite, gemini-3.1-pro)"
+        required: false
+        default: ""
 
 jobs:
   check-activity:
@@ -95,6 +99,9 @@ jobs:
         env:
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
         run: |
+          if [ -n "${{ github.event.inputs.model_id }}" ]; then
+            export EVAL_MODEL_ID="${{ github.event.inputs.model_id }}"
+          fi
           if [ -z "$GOOGLE_GENERATIVE_AI_API_KEY" ]; then
             echo "GOOGLE_GENERATIVE_AI_API_KEY secret is not configured; skipping live evals."
             echo "exit_code=0" >> "$GITHUB_OUTPUT"

--- a/src/tool-configs/index.ts
+++ b/src/tool-configs/index.ts
@@ -1,4 +1,5 @@
 import { createEvalTools } from "../tools/eval-tools.ts";
+import { strictEvalToolConfig } from "./strict-eval.ts";
 import type { ToolConfig } from "./types.ts";
 
 const baselineToolConfig: ToolConfig = {
@@ -14,6 +15,7 @@ const baselineToolConfig: ToolConfig = {
 /** toolConfigsById stores every named tool configuration available to evals. */
 export const toolConfigsById: Record<string, ToolConfig> = {
   [baselineToolConfig.id]: baselineToolConfig,
+  [strictEvalToolConfig.id]: strictEvalToolConfig,
 };
 
 /** defaultToolConfigId identifies the backwards-compatible eval tool set. */

--- a/src/tool-configs/strict-eval.ts
+++ b/src/tool-configs/strict-eval.ts
@@ -1,0 +1,14 @@
+import { createEvalTools } from "../tools/eval-tools.ts";
+import type { ToolConfig } from "./types.ts";
+
+export const strictEvalToolConfig: ToolConfig = {
+  id: "strict-eval",
+  description: "Baseline tools with strict step discipline prompt addition.",
+  discoveryName: "searchWorld",
+  queryName: "executeSparql",
+  requiredToolNames: ["searchWorld", "executeSparql"],
+  guardErrorSubstring: "Only read-only SPARQL queries are allowed",
+  factory: createEvalTools,
+  systemPromptAdditions:
+    "You MUST use exactly one searchWorld call and exactly one executeSparql call per case. Never exceed two total tool calls.",
+};

--- a/tests/tool-configs/tool-configs.test.ts
+++ b/tests/tool-configs/tool-configs.test.ts
@@ -28,3 +28,14 @@ Deno.test("compileEvalPrompt replaces semantic tool placeholders", () => {
     "Use searchWorld then executeSparql.",
   );
 });
+
+Deno.test("strict-eval config has system prompt additions", () => {
+  const toolConfig = resolveToolConfig("strict-eval");
+
+  assertEquals(toolConfig.id, "strict-eval");
+  assertEquals(typeof toolConfig.systemPromptAdditions, "string");
+  assertEquals(
+    toolConfig.systemPromptAdditions!.includes("Never exceed"),
+    true,
+  );
+});


### PR DESCRIPTION
## What

Two small infrastructure additions:

### 1. `strict-eval` tool config (Issue #15)

A new ToolConfig that wraps `baseline` tools with `systemPromptAdditions`:
```
"You MUST use exactly one searchWorld call and exactly one executeSparql call per case. Never exceed two total tool calls."
```

Validates the `systemPromptAdditions` hook on `ToolConfig`.

### 2. `model_id` CI input (Issue #16)

Adds `model_id` as a `workflow_dispatch` input so the suite can run against different Gemini tiers (e.g. `gemini-3.1-pro`) with one click.

## Comparison results (10 trials each)

The strict-eval prompt was **too restrictive** — "two total tool calls" cut short the search→SPARQL→answer pattern for scholar cases:

| Case | baseline | strict-eval | Delta |
|---|---|---|---|
| scholar-paper-venue | 100.0% | 30.0% | -70 pts |
| scholar-paper-author | 90.0% | 70.0% | -20 pts |
| scholar-paper-properties | 100.0% | 100.0% | 0 pts |
| 9 other cases | 100.0% | 100.0% | 0 pts |

The `systemPromptAdditions` hook works — the model obeyed the instruction — but the specific limit needs tuning (e.g., "three total calls") to not break the search→SPARQL→answer pattern.

## Files changed

- `src/tool-configs/strict-eval.ts` — new config with step-discipline prompt
- `src/tool-configs/index.ts` — register strict-eval
- `tests/tool-configs/tool-configs.test.ts` — add config resolution test
- `.github/workflows/evals.yml` — add `model_id` input, conditionally wire `EVAL_MODEL_ID`
