### PR TITLE
Floor-raiser upgrades: critical path, replay, model compare

### DIFF
--- a/.github/workflows/evals-pr.yml
+++ b/.github/workflows/evals-pr.yml
@@ -1,0 +1,69 @@
+name: Agent evals PR
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  critical-path-evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+
+      - name: Run critical-path live evals
+        id: eval
+        env:
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+        run: |
+          if [ -z "$GOOGLE_GENERATIVE_AI_API_KEY" ]; then
+            echo "GOOGLE_GENERATIVE_AI_API_KEY secret is not configured; skipping PR live evals."
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            echo "api_key_configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "api_key_configured=true" >> "$GITHUB_OUTPUT"
+
+          set +e
+          bun --env-file=.env run src/cli/run.ts \
+            --critical-path \
+            --trials 3 \
+            --min-pass-rate 1
+          EXIT_CODE=$?
+          set -e
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "::error::PR eval run aborted due to fatal API error (billing/quota/auth)."
+            exit 2
+          fi
+
+      - name: Upload PR eval results artifact
+        id: upload_results
+        if: steps.eval.outputs.api_key_configured == 'true' && steps.eval.outputs.exit_code != '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-pr-results-${{ github.run_id }}
+          path: results/*.json
+          if-no-files-found: error
+
+      - name: Render PR eval report
+        if: steps.eval.outputs.api_key_configured == 'true' && steps.eval.outputs.exit_code != '2'
+        env:
+          EXIT_CODE: ${{ steps.eval.outputs.exit_code }}
+        run: bun run scripts/render-eval-report.ts > eval-report.md
+
+      - name: Summarize PR eval results
+        if: steps.eval.outputs.api_key_configured == 'true' && steps.eval.outputs.exit_code != '2'
+        run: cat eval-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail job when critical-path evals did not pass
+        if: steps.eval.outputs.api_key_configured == 'true' && steps.eval.outputs.exit_code == '1'
+        run: |
+          echo "Critical-path live evals failed; see workflow logs and uploaded results."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ stay deferred until protocol assertions are stable.
 **CI on push and pull request:**
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `bun run ci` only
 (format, lint, unit tests). It does not call Gemini. Live agent evals run via
+[`.github/workflows/evals-pr.yml`](.github/workflows/evals-pr.yml) on pull
+requests (critical path only, when credentialed) and via
 [`.github/workflows/evals.yml`](.github/workflows/evals.yml) on manual dispatch
 or the weekly schedule when `GOOGLE_GENERATIVE_AI_API_KEY` is configured.
 
@@ -146,9 +148,67 @@ Add or tune a case when:
 | Iterate on one hypothesis | `--filter <case-id>` |
 | Measure stability | `--trials N --min-pass-rate <0-1>` |
 | Compare prompt or tool configs | `--compare baseline,strict-eval` |
+| Compare models on the same filter | `--compare-models gemini-a,gemini-b` |
+| Re-run assertions on a saved trace | `--replay results/latest.json` or `replays/*.json` |
+| Ship-gate critical path only | `--filter` using ids from [`critical-path.ts`](src/cases/critical-path.ts) |
 
 Incomplete, rate-limited, or credential-skipped live runs are operational signals
 only; do not cite them as benchmark evidence.
+
+### Critical path (ship gate)
+
+These case ids in [`src/cases/critical-path.ts`](src/cases/critical-path.ts) are the
+minimum live bar before shipping agent-facing changes:
+
+- `happy-path-search-then-sparql` — discover → SPARQL → grounded answer
+- `search-miss-unknown-label` — refuse to invent when discovery misses
+- `distractor-work-disambiguation` — pick the correct subject under noise
+- `sparql-updates-blocked` — read-only guard on mutating SPARQL
+- `memory-update-current-affiliation` — current session wins over stale literals
+
+Run locally:
+
+```sh
+bun run evals --filter /^(happy-path-search-then-sparql|search-miss-unknown-label|distractor-work-disambiguation|sparql-updates-blocked|memory-update-current-affiliation)$/ --trials 3 --min-pass-rate 1
+```
+
+Pull requests run the same slice via [`.github/workflows/evals-pr.yml`](.github/workflows/evals-pr.yml)
+when `GOOGLE_GENERATIVE_AI_API_KEY` is configured. The full catalog remains the weekly
+baseline in [`.github/workflows/evals.yml`](.github/workflows/evals.yml).
+
+### Production failure → eval case
+
+This harness is the **regression lock** for agent protocol behavior on seeded worlds.
+Raw production review happens outside this repo (application logs, support tickets, or
+your observability stack). When a failure class is real and repeatable:
+
+1. **Classify** the pattern (handoff miss, invented literal, guard bypass, refusal failure).
+2. **Reproduce** locally with `bun run evals --filter <case-id>` or capture a trace into
+   `results/*.json` and verify with `bun run evals --replay <path>`.
+3. **Fix** the smallest layer (proof, prompt, fixture) per Evaluation policy.
+4. **Lock in** only when an existing assertion `kind` cannot express the invariant:
+   add or extend a case in [`src/cases/index.ts`](src/cases/index.ts) and golden stub in
+   [`src/cases/test-fixtures.ts`](src/cases/test-fixtures.ts). Prefer extending an existing
+   case over adding a one-off edge case.
+5. **Optional commit** a minimal repro under `replays/` when the trajectory is the evidence
+   (no API key needed to re-assert).
+
+Minimum fields when promoting a prod failure: user prompt (or `promptTemplate`), ordered
+tool calls (`toolName`, `args`, `result`), final `output`, and which assertion should have
+caught it.
+
+### Eval case lifecycle (pruning)
+
+Add cases for **failure classes** that could regress on critical paths, not for every
+incident. Before adding a case, ask: is this critical path, representative of a class,
+and not already covered by proofs or an existing case?
+
+Review the catalog quarterly:
+
+- Remove or merge a case that has stayed at 100% pass rate for 90+ days **and** has had no
+  matching production recurrence.
+- Keep cases that encode protocol invariants even when green (guards, refusal, handoff).
+- Do not grow the suite toward benchmark coverage; 20 high-signal cases beats 200 edge cases.
 
 ### Reading failures
 
@@ -160,6 +220,7 @@ only; do not cite them as benchmark evidence.
 | `step-count-bounded` | Step budget respected | Case “fewest tool calls”; stricter tool config |
 | `updates-blocked` | Mutating SPARQL triggers read-only guard | Usually code ([`is-read-only-sparql-query.ts`](src/tools/is-read-only-sparql-query.ts)), not wording |
 | `final-answer-contains` | Final text includes expected literal | Case “exact literal only”; system “do not paraphrase” |
+| `final-answer-matches-one-of` | Final text includes one allowed refusal phrase | Miss-path cases; system “say not found” |
 | `output-excludes` | Final text must not include a literal | Case disambiguation or “say not found” |
 | `sparql-answer-grounded` | Literal appears in SPARQL bindings | Ensures answer came from query, not guess |
 | `sparql-answer-excludes` | Literal absent from bindings | OPTIONAL or absent-data scenarios |
@@ -195,7 +256,8 @@ no subject for an unknown work label:
 - **Prompt** instructs calling `{{discovery}}` with the unknown label, using
   `{{query}}` only if a URI is returned, and saying the fact was not found
   otherwise.
-- **Assertions** `output-excludes` (must not emit the seeded house literal) and
+- **Assertions** `states-not-found` (`final-answer-matches-one-of` refusal phrases),
+  `output-excludes` (must not emit the seeded house literal), and
   `literals-subset-of-tools` (no tracked fixture strings without tool evidence).
 - **System prompt** reinforces “say not found instead of guessing” in
   [`eval-agent-system-prompt.ts`](src/runner/eval-agent-system-prompt.ts).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ API key.
 | `--min-pass-rate`    | With `--trials`, require each case pass rate ≥ threshold (0–1); default requires 100% |
 | `--tool-config <id>` | Run with a named tool configuration (default `baseline`)                              |
 | `--compare <a,b>`    | Run the same selected cases against multiple tool configs and write a diff artifact   |
+| `--compare-models <a,b>` | Run the same filter against multiple `EVAL_MODEL_ID` values in parallel (cap: `EVAL_MODEL_CONCURRENCY`, default 2) |
+| `--replay <path>`    | Re-apply assertions to a saved suite or replay JSON without calling Gemini            |
+| `--critical-path`    | Shorthand for the ship-gate case filter (see [`src/cases/critical-path.ts`](src/cases/critical-path.ts)) |
 
 ## Output
 
@@ -68,9 +71,12 @@ API key.
 | Layer              | Command          | API key | When                                                                                                             |
 | :----------------- | :--------------- | :------ | :--------------------------------------------------------------------------------------------------------------- |
 | Unit tests         | `bun run ci`     | No      | Every push and pull request (GitHub `CI` workflow)                                                               |
+| PR critical path   | `--trials 3`      | Yes     | Pull requests when `GOOGLE_GENERATIVE_AI_API_KEY` is set ([`evals-pr.yml`](.github/workflows/evals-pr.yml))      |
 | Live agent evals   | `bun run evals`  | Yes     | Local dev; GitHub `Agent evals` workflow (manual dispatch)                                                       |
 | Scheduled baseline | `--trials 10`     | Yes     | Weekly (Mon 06:00 UTC), skipped if no harness commits in 7 days; uploads `results/*.json` as a workflow artifact |
 | Manual dispatch    | configurable      | Yes     | Same workflow artifact flow as the scheduled baseline                                                            |
+
+Critical-path case ids and the production→case playbook live in [AGENTS.md](AGENTS.md#critical-path-ship-gate).
 
 ## Layout
 
@@ -83,7 +89,10 @@ API key.
 | `src/assertions/assertion-registry.ts`  | Composable assertion kinds (`runAssertionSpecs`) |
 | `src/assertions/trajectory-reducers.ts` | Shared trajectory extractors and diagnostics     |
 | `src/cases/index.ts`                    | Eval case catalog (prompts + assertion specs)    |
+| `src/cases/critical-path.ts`            | Ship-gate case ids and filter helper             |
 | `src/cases/test-fixtures.ts`            | Golden trajectories and outputs for case tests   |
+| `src/replay/run-replay.ts`              | Offline trajectory replay (`--replay`)           |
+| `replays/`                              | Committed repro documents for replay             |
 | `src/fixtures/index.ts`                 | Seeded world fixture registry                    |
 | `src/runner/run-eval-suite.ts`          | Suite orchestration, stats, and compare assembly |
 | `src/results/result-store.ts`           | Result artifact paths and JSON persistence       |

--- a/replays/search-miss-unknown-label.replay.json
+++ b/replays/search-miss-unknown-label.replay.json
@@ -1,0 +1,14 @@
+{
+  "caseId": "search-miss-unknown-label",
+  "toolConfigId": "baseline",
+  "output": "No matching work was found in the graph.",
+  "runCompleted": true,
+  "trajectory": [
+    {
+      "stepIndex": 0,
+      "toolName": "searchWorld",
+      "args": { "query": "z9Qk4WnP" },
+      "result": { "success": true, "results": [] }
+    }
+  ]
+}

--- a/scripts/render-eval-report.ts
+++ b/scripts/render-eval-report.ts
@@ -1,7 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { extractFirstSparqlQueryExcerpt } from "@/assertions/trajectory-reducers.ts";
 import { buildTable, formatPercent } from "@/reporting/markdown-table.ts";
 import { synthesizeStatsFromSuite } from "@/runner/run-eval-suite.ts";
+import {
+  defaultToolConfigId,
+  resolveToolConfig,
+} from "@/tool-configs/index.ts";
 import type {
   EvalAssertionPassRate,
   EvalCasePassRate,
@@ -200,24 +205,38 @@ function buildFinalFailureRows(
     return [];
   }
 
+  const queryToolName = resolveToolConfig(
+    suiteResult.toolConfigId ?? defaultToolConfigId,
+  ).queryName;
+
   return suiteResult.results
     .filter((caseResult: EvalCaseResult) => !caseResult.success)
     .map((caseResult) => {
-      const failedAssertions = caseResult.assertions
+      const failedAssertionDetails = caseResult.assertions
         .filter((assertion) => !assertion.pass)
-        .map((assertion) => assertion.name)
-        .join(", ");
+        .map((assertion) => {
+          if (assertion.message) {
+            return `${assertion.name}: ${assertion.message}`;
+          }
+          return assertion.name;
+        })
+        .join(" | ");
       const toolSequence =
         caseResult.toolSequence.length > 0
           ? caseResult.toolSequence.join(" -> ")
           : "(none)";
+      const sparqlExcerpt = extractFirstSparqlQueryExcerpt(
+        caseResult.metadata.trajectory,
+        queryToolName,
+      );
       const diagnosticExcerpt =
         caseResult.error || caseResult.output || "(empty)";
 
       return [
         caseResult.id,
-        failedAssertions || "(none)",
+        truncateCell(failedAssertionDetails || "(none)"),
         toolSequence,
+        truncateCell(sparqlExcerpt),
         truncateCell(diagnosticExcerpt),
       ];
     });
@@ -352,7 +371,13 @@ export function renderEvalReport(input: EvalReportInput): string {
     reportSections.push("## Final-trial failures");
     reportSections.push(
       buildTable(
-        ["Case", "Failed assertions", "Tools", "Error/output"],
+        [
+          "Case",
+          "Failed assertions",
+          "Tools",
+          "SPARQL excerpt",
+          "Error/output",
+        ],
         finalFailureRows,
       ),
     );

--- a/scripts/render-model-compare-report.ts
+++ b/scripts/render-model-compare-report.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { buildTable, formatPercent } from "@/reporting/markdown-table.ts";
+import type { EvalModelCompareResult } from "@/types.ts";
+
+const DEFAULT_RESULTS_DIRECTORY = "results";
+
+/** readModelCompareResult loads the newest compare-models artifact when present. */
+async function readModelCompareResult(): Promise<
+  EvalModelCompareResult | undefined
+> {
+  const configuredPath = process.env.MODEL_COMPARE_RESULT_PATH;
+  if (configuredPath) {
+    return JSON.parse(
+      await readFile(configuredPath, "utf8"),
+    ) as EvalModelCompareResult;
+  }
+
+  const resultsDirectory =
+    process.env.RESULTS_DIRECTORY ?? DEFAULT_RESULTS_DIRECTORY;
+  const { readdir } = await import("node:fs/promises");
+  const entryNames = await readdir(resultsDirectory);
+  const compareFileName = entryNames.find((entryName) =>
+    entryName.startsWith("compare-models-"),
+  );
+  if (!compareFileName) {
+    return undefined;
+  }
+
+  return JSON.parse(
+    await readFile(join(resultsDirectory, compareFileName), "utf8"),
+  ) as EvalModelCompareResult;
+}
+
+/** renderModelCompareReport renders model comparison JSON as Markdown. */
+export function renderModelCompareReport(
+  compareResult: EvalModelCompareResult,
+): string {
+  const reportSections: string[] = [];
+  reportSections.push("## Model comparison report");
+  reportSections.push(
+    buildTable(
+      ["Field", "Value"],
+      [
+        ["Provider", compareResult.providerId],
+        ["Tool config", compareResult.toolConfigId],
+        ["Models", compareResult.modelIds.join(", ")],
+        ["Trials", String(compareResult.trialCount)],
+        [
+          "Minimum pass rate",
+          compareResult.minPassRate === undefined
+            ? "100%"
+            : formatPercent(compareResult.minPassRate),
+        ],
+      ],
+    ),
+  );
+  reportSections.push("## Case pass rates by model");
+  reportSections.push(
+    buildTable(
+      ["Case", ...compareResult.modelIds],
+      compareResult.caseComparisons.map((caseComparison) => [
+        caseComparison.id,
+        ...compareResult.modelIds.map((compareModelId) => {
+          const casePassRate =
+            caseComparison.passRatesByModelId[compareModelId];
+          if (!casePassRate) {
+            return "n/a";
+          }
+          return `${casePassRate.passCount}/${casePassRate.trialCount} (${formatPercent(casePassRate.passRate)})`;
+        }),
+      ]),
+    ),
+  );
+
+  return `${reportSections.join("\n\n")}\n`;
+}
+
+if (import.meta.main) {
+  const compareResult = await readModelCompareResult();
+  if (!compareResult) {
+    console.log("No model comparison result JSON was found.");
+    process.exit(1);
+  }
+  console.log(renderModelCompareReport(compareResult));
+}

--- a/src/assertions/assertion-registry.ts
+++ b/src/assertions/assertion-registry.ts
@@ -134,6 +134,23 @@ function runAssertionSpec(
             )}; ${diagnosticSuffix}`,
       };
     }
+    case "final-answer-matches-one-of": {
+      const normalizedOutput = normalizeOutputText(result.output);
+      const matchedPhrase = spec.phrases.find((phrase) =>
+        normalizedOutput.includes(normalizeOutputText(phrase)),
+      );
+      const pass = matchedPhrase !== undefined;
+      return {
+        name: spec.name,
+        pass,
+        message: pass
+          ? undefined
+          : `Expected output to include one of [${spec.phrases.join(", ")}]; got: ${result.output.slice(
+              0,
+              200,
+            )}; ${diagnosticSuffix}`,
+      };
+    }
     case "output-excludes": {
       const normalizedOutput = normalizeOutputText(result.output);
       const forbiddenSubstring = normalizeOutputText(spec.literal);

--- a/src/assertions/trajectory-reducers.ts
+++ b/src/assertions/trajectory-reducers.ts
@@ -154,6 +154,27 @@ export function collectToolOutputLiterals(
   return [...literalSet];
 }
 
+/** extractFirstSparqlQueryExcerpt returns a compact SPARQL args preview from a trajectory. */
+export function extractFirstSparqlQueryExcerpt(
+  trajectory: EvalToolRecord[],
+  queryToolName: string,
+  maxLength = 160,
+): string {
+  const sparqlStep = trajectory.find(
+    (record) => record.toolName === queryToolName,
+  );
+  if (!sparqlStep) {
+    return "(no SPARQL call)";
+  }
+
+  const serializedArgs = JSON.stringify(sparqlStep.args ?? {});
+  if (serializedArgs.length <= maxLength) {
+    return serializedArgs;
+  }
+
+  return `${serializedArgs.slice(0, maxLength - 3)}...`;
+}
+
 /** formatTrajectoryDiagnostic summarizes tool usage for assertion failure messages. */
 export function formatTrajectoryDiagnostic(result: EvalCaseResult): string {
   const toolSequence = result.metadata.trajectory

--- a/src/cases/critical-path.ts
+++ b/src/cases/critical-path.ts
@@ -1,0 +1,19 @@
+/** criticalPathCaseIds lists eval cases that must pass live before shipping agent changes. */
+export const criticalPathCaseIds = [
+  "happy-path-search-then-sparql",
+  "search-miss-unknown-label",
+  "distractor-work-disambiguation",
+  "sparql-updates-blocked",
+  "memory-update-current-affiliation",
+] as const;
+
+/** CriticalPathCaseId names one ship-gate eval case id. */
+export type CriticalPathCaseId = (typeof criticalPathCaseIds)[number];
+
+/** buildCriticalPathFilterRegex compiles a filter that matches only critical-path case ids. */
+export function buildCriticalPathFilterRegex(): RegExp {
+  const escapedCaseIds = criticalPathCaseIds.map((caseId) =>
+    caseId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+  );
+  return new RegExp(`^(${escapedCaseIds.join("|")})$`);
+}

--- a/src/cases/index.ts
+++ b/src/cases/index.ts
@@ -32,6 +32,7 @@ import {
   MEMORY_STALE_AFFILIATION_LITERAL,
   UNKNOWN_MEMORY_AGENT_SEARCH_LABEL,
 } from "@/fixtures/memory-world.ts";
+import { REFUSAL_PHRASES } from "@/fixtures/refusal-phrases.ts";
 
 /** protocolAssertions bundles the standard discover-then-verify checks. */
 function protocolAssertions(maxSteps: number): AssertionSpec[] {
@@ -84,6 +85,11 @@ function negativeSearchMissAssertions(
   maxSteps: number,
 ): AssertionSpec[] {
   return [
+    {
+      name: "states-not-found",
+      kind: "final-answer-matches-one-of",
+      phrases: [...REFUSAL_PHRASES],
+    },
     {
       name: assertionName,
       kind: "output-excludes",

--- a/src/cases/test-fixtures.ts
+++ b/src/cases/test-fixtures.ts
@@ -189,7 +189,7 @@ export const caseTestFixtures: Record<string, EvalCaseTestFixture> = {
         result: { success: true, results: [] },
       },
     ],
-    output: "No location found in the graph.",
+    output: "The fact was not found in the graph.",
   },
   "hierarchy-optional-pattern": {
     trajectory: createTrajectory(HIERARCHY_NEST_SUBJECT_URI, {}),

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,12 +1,17 @@
 import { parseArgs as nodeParseArgs } from "node:util";
 import { evalCases } from "@/cases/index.ts";
+import { buildCriticalPathFilterRegex } from "@/cases/critical-path.ts";
 import {
   writeCompareResult,
+  writeModelCompareResult,
   writeStatsResult,
   writeSuiteResult,
 } from "@/results/result-store.ts";
+import { runReplayFile } from "@/replay/run-replay.ts";
 import {
   buildCompareResult,
+  buildModelCompareResult,
+  runEvalSuiteForModels,
   runEvalSuiteForToolConfig,
 } from "@/runner/run-eval-suite.ts";
 import {
@@ -17,6 +22,7 @@ import {
 import type {
   EvalCaseDefinition,
   EvalCompareResult,
+  EvalModelCompareResult,
   EvalStatsResult,
   EvalSuiteResult,
 } from "@/types.ts";
@@ -33,6 +39,10 @@ interface EvalCliOptions {
   minPassRate?: number;
   toolConfigId: string;
   compareToolConfigIds?: string[];
+  compareModelIds?: string[];
+  modelConcurrency: number;
+  replayPath?: string;
+  criticalPath: boolean;
 }
 
 /** validateProviderId prevents mislabeled provider metadata in eval results. */
@@ -96,7 +106,7 @@ function parsePassRateOption(
 }
 
 const supportedCliFlags =
-  "--filter <pattern>, --list, --permit-no-files, --trials <N>, --min-pass-rate <0-1>, --tool-config <name>, --compare <a,b>";
+  "--filter <pattern>, --list, --permit-no-files, --trials <N>, --min-pass-rate <0-1>, --tool-config <name>, --compare <a,b>, --compare-models <a,b>, --replay <path>, --critical-path";
 
 /** parseCliOptions reads supported targeting flags from process.argv. */
 export function parseCliOptions(args: string[]): EvalCliOptions {
@@ -112,6 +122,9 @@ export function parseCliOptions(args: string[]): EvalCliOptions {
         "min-pass-rate": { type: "string" },
         "tool-config": { type: "string" },
         compare: { type: "string" },
+        "compare-models": { type: "string" },
+        replay: { type: "string" },
+        "critical-path": { type: "boolean", default: false },
       },
       strict: true,
       allowPositionals: false,
@@ -150,6 +163,14 @@ export function parseCliOptions(args: string[]): EvalCliOptions {
         .map((toolConfigId) => toolConfigId.trim())
         .filter((toolConfigId) => toolConfigId.length > 0)
     : undefined;
+  const compareModelIds = parsedArgs["compare-models"]
+    ? String(parsedArgs["compare-models"])
+        .split(",")
+        .map((compareModelId) => compareModelId.trim())
+        .filter((compareModelId) => compareModelId.length > 0)
+    : undefined;
+  const replayPath = parsedArgs.replay ? String(parsedArgs.replay) : undefined;
+  const criticalPath = parsedArgs["critical-path"] === true;
 
   if (compareToolConfigIds && compareToolConfigIds.length < 2) {
     throw new Error("--compare must include at least two tool config ids");
@@ -160,19 +181,56 @@ export function parseCliOptions(args: string[]): EvalCliOptions {
   ) {
     throw new Error("--compare tool config ids must be unique");
   }
+  if (compareModelIds && compareModelIds.length < 2) {
+    throw new Error("--compare-models must include at least two model ids");
+  }
+  if (
+    compareModelIds &&
+    new Set(compareModelIds).size !== compareModelIds.length
+  ) {
+    throw new Error("--compare-models model ids must be unique");
+  }
+  if (compareToolConfigIds && compareModelIds) {
+    throw new Error("Use either --compare or --compare-models, not both");
+  }
+  if (replayPath && (compareToolConfigIds || compareModelIds)) {
+    throw new Error(
+      "--replay cannot be combined with --compare or --compare-models",
+    );
+  }
+
+  let resolvedFilter = filter;
+  if (criticalPath) {
+    if (filter) {
+      throw new Error("--critical-path cannot be combined with --filter");
+    }
+    resolvedFilter = buildCriticalPathFilterRegex();
+  }
+
+  const modelConcurrency = Number.parseInt(
+    process.env.EVAL_MODEL_CONCURRENCY ?? "2",
+    10,
+  );
 
   if (!Number.isFinite(trialCount) || trialCount < 1) {
     trialCount = 1;
   }
 
   return {
-    filter,
+    filter: resolvedFilter,
     list,
     permitNoFiles,
     trialCount,
     minPassRate,
     toolConfigId,
     compareToolConfigIds,
+    compareModelIds,
+    modelConcurrency:
+      Number.isFinite(modelConcurrency) && modelConcurrency > 0
+        ? modelConcurrency
+        : 2,
+    replayPath,
+    criticalPath,
   };
 }
 
@@ -270,6 +328,48 @@ function buildSuiteRunOptions(cliOptions: EvalCliOptions) {
   };
 }
 
+/** printModelCompareSummary renders a compact terminal model comparison table. */
+function printModelCompareSummary(compareResult: EvalModelCompareResult): void {
+  console.log(`Models: ${compareResult.modelIds.join(", ")}`);
+  console.log(`Tool config: ${compareResult.toolConfigId}`);
+  console.log(`Trials per case: ${compareResult.trialCount}`);
+  console.log("");
+
+  for (const comparison of compareResult.caseComparisons) {
+    const rates = compareResult.modelIds.map((compareModelId) => {
+      const casePassRate = comparison.passRatesByModelId[compareModelId];
+      const percentage = casePassRate
+        ? `${(casePassRate.passRate * 100).toFixed(1)}%`
+        : "n/a";
+      return `${compareModelId}=${percentage}`;
+    });
+    console.log(`${comparison.id}: ${rates.join(", ")}`);
+  }
+}
+
+/** printReplaySummary renders replay assertion outcomes. */
+function printReplaySummary(
+  replayPath: string,
+  results: Awaited<ReturnType<typeof runReplayFile>>,
+): void {
+  console.log(`Replay source: ${replayPath}`);
+  console.log(`Replay success: ${results.success}`);
+  console.log("");
+
+  for (const replayResult of results.results) {
+    console.log(
+      `[${replayResult.success ? "PASS" : "FAIL"}] ${replayResult.caseId}`,
+    );
+    for (const assertion of replayResult.assertions) {
+      console.log(`  - ${assertion.pass ? "PASS" : "FAIL"}: ${assertion.name}`);
+      if (!assertion.pass && assertion.message) {
+        console.log(`    ${assertion.message}`);
+      }
+    }
+    console.log("");
+  }
+}
+
 /** printCompareSummary renders a compact terminal comparison table. */
 function printCompareSummary(compareResult: EvalCompareResult): void {
   console.log(`Tool configs: ${compareResult.toolConfigIds.join(", ")}`);
@@ -292,6 +392,16 @@ if (import.meta.main) {
   validateProviderId(providerId);
 
   const cliOptions = parseCliOptions(process.argv.slice(2));
+
+  if (cliOptions.replayPath) {
+    const replayResult = await runReplayFile(cliOptions.replayPath);
+    printReplaySummary(cliOptions.replayPath, replayResult);
+    if (!replayResult.success) {
+      process.exitCode = 1;
+    }
+    process.exit();
+  }
+
   const selectedEvalCases = selectEvalCases(evalCases, cliOptions);
 
   if (cliOptions.list) {
@@ -307,6 +417,50 @@ if (import.meta.main) {
     }
 
     throw new Error(message);
+  }
+
+  if (cliOptions.compareModelIds) {
+    const toolConfig = resolveToolConfig(cliOptions.toolConfigId);
+    const modelRunResult = await runEvalSuiteForModels(
+      selectedEvalCases,
+      toolConfig,
+      cliOptions.compareModelIds,
+      {
+        providerId,
+        trialCount: cliOptions.trialCount,
+        minPassRate: cliOptions.minPassRate,
+        modelConcurrency: cliOptions.modelConcurrency,
+      },
+    );
+
+    if (modelRunResult.fatalError) {
+      console.log(
+        `\nRun aborted due to fatal API error: ${modelRunResult.fatalError}`,
+      );
+      process.exitCode = 2;
+      process.exit();
+    }
+
+    const modelCompareResult = buildModelCompareResult(
+      selectedEvalCases,
+      modelRunResult.statsResults,
+      {
+        providerId,
+        modelId: cliOptions.compareModelIds[0] ?? modelId,
+        trialCount: cliOptions.trialCount,
+        minPassRate: cliOptions.minPassRate,
+        toolConfigId: toolConfig.id,
+      },
+    );
+    printModelCompareSummary(modelCompareResult);
+    const modelCompareOutputPath =
+      await writeModelCompareResult(modelCompareResult);
+    console.log(`Wrote model comparison results to ${modelCompareOutputPath}`);
+
+    if (modelRunResult.failed) {
+      process.exitCode = 1;
+    }
+    process.exit();
   }
 
   if (cliOptions.compareToolConfigIds) {

--- a/src/fixtures/refusal-phrases.ts
+++ b/src/fixtures/refusal-phrases.ts
@@ -1,0 +1,11 @@
+/** REFUSAL_PHRASES lists normalized substrings that satisfy epistemic refusal assertions. */
+export const REFUSAL_PHRASES = [
+  "not found",
+  "could not find",
+  "couldn't find",
+  "no matching",
+  "was not found",
+  "cannot find",
+  "can't find",
+  "unable to find",
+] as const;

--- a/src/replay/run-replay.ts
+++ b/src/replay/run-replay.ts
@@ -1,0 +1,168 @@
+import { readFile } from "node:fs/promises";
+import { applyAssertions } from "@/assertions/apply-assertions.ts";
+import { evalCases } from "@/cases/index.ts";
+import { compileEvalPrompt, resolveToolConfig } from "@/tool-configs/index.ts";
+import type {
+  EvalCaseResult,
+  EvalReplayDocument,
+  EvalSuiteResult,
+  EvalToolRecord,
+} from "@/types.ts";
+
+/** ReplayRunResult stores one replayed case outcome. */
+export interface ReplayRunResult {
+  caseId: string;
+  success: boolean;
+  assertions: EvalCaseResult["assertions"];
+  output: string;
+}
+
+/** ReplaySuiteResult stores outcomes for every replayed case in one file. */
+export interface ReplaySuiteResult {
+  sourcePath: string;
+  success: boolean;
+  results: ReplayRunResult[];
+}
+
+/** isEvalSuiteResult narrows parsed JSON to a full suite artifact shape. */
+function isEvalSuiteResult(value: unknown): value is EvalSuiteResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "results" in value &&
+    Array.isArray((value as EvalSuiteResult).results)
+  );
+}
+
+/** isEvalReplayDocument narrows parsed JSON to a replay document shape. */
+function isEvalReplayDocument(value: unknown): value is EvalReplayDocument {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "caseId" in value &&
+    "trajectory" in value &&
+    "output" in value &&
+    Array.isArray((value as EvalReplayDocument).trajectory)
+  );
+}
+
+/** buildEvalCaseResultFromReplay constructs a case result for assertion replay. */
+function buildEvalCaseResultFromReplay(
+  replayDocument: EvalReplayDocument,
+  description: string,
+  prompt: string,
+): EvalCaseResult {
+  const trajectory: EvalToolRecord[] = replayDocument.trajectory;
+  const stepCount =
+    replayDocument.stepCount ??
+    (trajectory.length > 0
+      ? Math.max(...trajectory.map((record) => record.stepIndex)) + 1
+      : 0);
+
+  return {
+    id: replayDocument.caseId,
+    description,
+    prompt,
+    output: replayDocument.output,
+    runCompleted:
+      replayDocument.runCompleted ?? replayDocument.error === undefined,
+    success: false,
+    metadata: {
+      providerId: replayDocument.providerId ?? "replay",
+      modelId: replayDocument.modelId ?? "replay",
+      stepCount,
+      latencyMs: replayDocument.latencyMs ?? 0,
+      trajectory,
+    },
+    assertions: [],
+    toolSequence: trajectory.map((record) => record.toolName),
+    error: replayDocument.error,
+  };
+}
+
+/** replayEvalCase applies assertions to one replay document without calling Gemini. */
+export function replayEvalCase(
+  replayDocument: EvalReplayDocument,
+): ReplayRunResult {
+  const evalCase = evalCases.find(
+    (testCase) => testCase.id === replayDocument.caseId,
+  );
+  if (!evalCase) {
+    throw new Error(
+      `Unknown replay case id "${replayDocument.caseId}"; add it to src/cases/index.ts first.`,
+    );
+  }
+
+  const toolConfig = resolveToolConfig(
+    replayDocument.toolConfigId ?? "baseline",
+  );
+  const prompt = compileEvalPrompt(
+    evalCase.promptTemplate ?? evalCase.prompt ?? "",
+    toolConfig,
+  );
+
+  const rawResult = buildEvalCaseResultFromReplay(
+    replayDocument,
+    evalCase.description,
+    prompt,
+  );
+  const assertedResult = applyAssertions(
+    rawResult,
+    evalCase.assertions,
+    toolConfig,
+  );
+
+  return {
+    caseId: assertedResult.id,
+    success: assertedResult.success,
+    assertions: assertedResult.assertions,
+    output: assertedResult.output,
+  };
+}
+
+/** loadReplayDocuments reads one suite artifact or one replay document from disk. */
+export async function loadReplayDocuments(
+  replayPath: string,
+): Promise<EvalReplayDocument[]> {
+  const fileContents = await readFile(replayPath, "utf8");
+  const parsedJson: unknown = JSON.parse(fileContents);
+
+  if (isEvalSuiteResult(parsedJson)) {
+    return parsedJson.results.map((caseResult) => ({
+      caseId: caseResult.id,
+      toolConfigId: parsedJson.toolConfigId,
+      output: caseResult.output,
+      runCompleted: caseResult.runCompleted,
+      trajectory: caseResult.metadata.trajectory,
+      providerId: caseResult.metadata.providerId,
+      modelId: caseResult.metadata.modelId,
+      stepCount: caseResult.metadata.stepCount,
+      latencyMs: caseResult.metadata.latencyMs,
+      error: caseResult.error,
+    }));
+  }
+
+  if (isEvalReplayDocument(parsedJson)) {
+    return [parsedJson];
+  }
+
+  throw new Error(
+    `Unsupported replay JSON at ${replayPath}; expected EvalSuiteResult or EvalReplayDocument.`,
+  );
+}
+
+/** runReplayFile replays every case encoded in one JSON file. */
+export async function runReplayFile(
+  replayPath: string,
+): Promise<ReplaySuiteResult> {
+  const replayDocuments = await loadReplayDocuments(replayPath);
+  const results = replayDocuments.map((replayDocument) =>
+    replayEvalCase(replayDocument),
+  );
+
+  return {
+    sourcePath: replayPath,
+    success: results.every((result) => result.success),
+    results,
+  };
+}

--- a/src/results/result-store.ts
+++ b/src/results/result-store.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
   EvalCompareResult,
+  EvalModelCompareResult,
   EvalStatsResult,
   EvalSuiteResult,
 } from "@/types.ts";
@@ -65,6 +66,20 @@ export async function writeCompareResult(
   const outputPath = join(
     resultsDirectory,
     buildResultFileName("compare", result.toolConfigIds.join("-vs-")),
+  );
+  await mkdir(resultsDirectory, { recursive: true });
+  await writeFile(outputPath, JSON.stringify(result, null, 2), "utf8");
+  return outputPath;
+}
+
+/** writeModelCompareResult persists side-by-side model comparison data. */
+export async function writeModelCompareResult(
+  result: EvalModelCompareResult,
+): Promise<string> {
+  const resultsDirectory = resolveResultsDirectory();
+  const outputPath = join(
+    resultsDirectory,
+    buildResultFileName("compare-models", result.modelIds.join("-vs-")),
   );
   await mkdir(resultsDirectory, { recursive: true });
   await writeFile(outputPath, JSON.stringify(result, null, 2), "utf8");

--- a/src/runner/run-eval-suite.ts
+++ b/src/runner/run-eval-suite.ts
@@ -1,4 +1,5 @@
 import { applyAssertions } from "@/assertions/index.ts";
+import { writeStatsResult, writeSuiteResult } from "@/results/result-store.ts";
 import { defaultToolConfigId } from "@/tool-configs/index.ts";
 import type { ToolConfig } from "@/tool-configs/types.ts";
 import type {
@@ -7,10 +8,12 @@ import type {
   EvalCasePassRate,
   EvalCaseResult,
   EvalCompareResult,
+  EvalModelCompareResult,
   EvalStatsResult,
   EvalSuiteResult,
 } from "@/types.ts";
 import { runEvalCase } from "./run-eval-case.ts";
+import { runParallelTasks } from "./run-parallel-tasks.ts";
 
 /** EvalSuiteRunOptions configures provider metadata for one suite execution. */
 export interface EvalSuiteRunOptions {
@@ -19,6 +22,7 @@ export interface EvalSuiteRunOptions {
   trialCount: number;
   minPassRate?: number;
   compareMode?: boolean;
+  modelCompareMode?: boolean;
 }
 
 /** EvalToolConfigRunResult stores one tool config's suite and stats outputs. */
@@ -245,7 +249,10 @@ export async function runEvalSuiteForToolConfig(
   }
 
   const suiteResult = trialSuiteResults[trialSuiteResults.length - 1];
-  const shouldAggregateStats = options.trialCount > 1 || options.compareMode;
+  const shouldAggregateStats =
+    options.trialCount > 1 ||
+    options.compareMode === true ||
+    options.modelCompareMode === true;
   const statsResult = shouldAggregateStats
     ? aggregateEvalStats(
         selectedEvalCases,
@@ -258,4 +265,102 @@ export async function runEvalSuiteForToolConfig(
     : undefined;
 
   return { suiteResult, statsResult, fatalError };
+}
+
+/** buildModelCompareResult creates side-by-side stats for multiple model ids. */
+export function buildModelCompareResult(
+  selectedCases: EvalCaseDefinition[],
+  statsResults: EvalStatsResult[],
+  options: EvalSuiteRunOptions & { toolConfigId: string },
+): EvalModelCompareResult {
+  const modelIds = statsResults.map((statsResult) => statsResult.modelId);
+
+  return {
+    providerId: options.providerId,
+    toolConfigId: options.toolConfigId,
+    timestamp: new Date().toISOString(),
+    trialCount: options.trialCount,
+    minPassRate: options.minPassRate,
+    baselineModelId: modelIds[0] ?? options.modelId,
+    modelIds,
+    statsResults,
+    caseComparisons: selectedCases.map((testCase) => ({
+      id: testCase.id,
+      description: testCase.description,
+      passRatesByModelId: Object.fromEntries(
+        statsResults.flatMap((statsResult) => {
+          const casePassRate = statsResult.casePassRates.find(
+            (entry) => entry.id === testCase.id,
+          );
+          return casePassRate ? [[statsResult.modelId, casePassRate]] : [];
+        }),
+      ),
+    })),
+  };
+}
+
+/** runEvalSuiteForModels runs the same cases against multiple models in parallel. */
+export async function runEvalSuiteForModels(
+  selectedEvalCases: EvalCaseDefinition[],
+  toolConfig: ToolConfig,
+  modelIds: string[],
+  options: Omit<EvalSuiteRunOptions, "modelId"> & { modelConcurrency: number },
+): Promise<{
+  statsResults: EvalStatsResult[];
+  fatalError?: string;
+  failed: boolean;
+}> {
+  const parallelResults = await runParallelTasks(
+    modelIds.map((modelId) => async () => {
+      const runResult = await runEvalSuiteForToolConfig(
+        selectedEvalCases,
+        toolConfig,
+        {
+          ...options,
+          modelId,
+          modelCompareMode: true,
+        },
+      );
+      return { modelId, runResult };
+    }),
+    options.modelConcurrency,
+  );
+
+  const statsResults: EvalStatsResult[] = [];
+  let fatalError: string | undefined;
+  let failed = false;
+
+  for (const parallelResult of parallelResults) {
+    if (parallelResult.runResult.fatalError) {
+      fatalError = parallelResult.runResult.fatalError;
+    }
+    if (parallelResult.runResult.statsResult) {
+      statsResults.push(parallelResult.runResult.statsResult);
+      if (!parallelResult.runResult.statsResult.success) {
+        failed = true;
+      }
+    } else if (!parallelResult.runResult.suiteResult.success) {
+      failed = true;
+    }
+
+    const latestOutputPath = await writeSuiteResult(
+      parallelResult.runResult.suiteResult,
+      parallelResult.modelId,
+    );
+    console.log(
+      `Wrote ${parallelResult.modelId} results to ${latestOutputPath}`,
+    );
+
+    if (parallelResult.runResult.statsResult) {
+      const statsOutputPath = await writeStatsResult(
+        parallelResult.runResult.statsResult,
+        parallelResult.modelId,
+      );
+      console.log(
+        `Wrote ${parallelResult.modelId} statistical results to ${statsOutputPath}`,
+      );
+    }
+  }
+
+  return { statsResults, fatalError, failed };
 }

--- a/src/runner/run-parallel-tasks.ts
+++ b/src/runner/run-parallel-tasks.ts
@@ -1,0 +1,30 @@
+/** runParallelTasks executes async tasks with a bounded concurrency limit. */
+export async function runParallelTasks<TaskResult>(
+  taskFactories: Array<() => Promise<TaskResult>>,
+  concurrencyLimit: number,
+): Promise<TaskResult[]> {
+  if (taskFactories.length === 0) {
+    return [];
+  }
+
+  const boundedConcurrency = Math.max(1, Math.floor(concurrencyLimit));
+  const taskResults: TaskResult[] = new Array(taskFactories.length);
+  let nextTaskIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextTaskIndex < taskFactories.length) {
+      const currentTaskIndex = nextTaskIndex;
+      nextTaskIndex += 1;
+      const taskFactory = taskFactories[currentTaskIndex];
+      if (!taskFactory) {
+        continue;
+      }
+      taskResults[currentTaskIndex] = await taskFactory();
+    }
+  }
+
+  const workerCount = Math.min(boundedConcurrency, taskFactories.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+  return taskResults;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type AssertionSpecKind =
   | "step-count-bounded"
   | "updates-blocked"
   | "final-answer-contains"
+  | "final-answer-matches-one-of"
   | "output-excludes"
   | "sparql-answer-grounded"
   | "sparql-answer-excludes"
@@ -54,6 +55,7 @@ export type AssertionSpec =
   | { name: string; kind: "step-count-bounded"; maxSteps: number }
   | { name: string; kind: "updates-blocked" }
   | { name: string; kind: "final-answer-contains"; literal: string }
+  | { name: string; kind: "final-answer-matches-one-of"; phrases: string[] }
   | { name: string; kind: "output-excludes"; literal: string }
   | { name: string; kind: "sparql-answer-grounded"; literal: string }
   | { name: string; kind: "sparql-answer-excludes"; literal: string }
@@ -150,4 +152,38 @@ export interface EvalCompareResult {
   toolConfigIds: string[];
   statsResults: EvalStatsResult[];
   caseComparisons: EvalCaseComparison[];
+}
+
+/** EvalCaseModelComparison summarizes one case across multiple model ids. */
+export interface EvalCaseModelComparison {
+  id: string;
+  description: string;
+  passRatesByModelId: Record<string, EvalCasePassRate>;
+}
+
+/** EvalModelCompareResult stores side-by-side statistics for model capability runs. */
+export interface EvalModelCompareResult {
+  providerId: string;
+  toolConfigId: string;
+  timestamp: string;
+  trialCount: number;
+  minPassRate?: number;
+  baselineModelId: string;
+  modelIds: string[];
+  statsResults: EvalStatsResult[];
+  caseComparisons: EvalCaseModelComparison[];
+}
+
+/** EvalReplayDocument stores a captured trajectory for offline assertion replay. */
+export interface EvalReplayDocument {
+  caseId: string;
+  toolConfigId?: string;
+  output: string;
+  runCompleted?: boolean;
+  trajectory: EvalToolRecord[];
+  providerId?: string;
+  modelId?: string;
+  stepCount?: number;
+  latencyMs?: number;
+  error?: string;
 }

--- a/tests/cases/critical-path.test.ts
+++ b/tests/cases/critical-path.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import {
+  buildCriticalPathFilterRegex,
+  criticalPathCaseIds,
+} from "@/cases/critical-path.ts";
+import { evalCases } from "@/cases/index.ts";
+
+test("criticalPathCaseIds resolve to catalog entries", () => {
+  for (const caseId of criticalPathCaseIds) {
+    expect(evalCases.some((evalCase) => evalCase.id === caseId)).toBe(true);
+  }
+});
+
+test("buildCriticalPathFilterRegex matches only critical-path ids", () => {
+  const criticalPathFilter = buildCriticalPathFilterRegex();
+  const matchedIds = evalCases
+    .filter((evalCase) => criticalPathFilter.test(evalCase.id))
+    .map((evalCase) => evalCase.id);
+
+  expect(matchedIds.toSorted()).toEqual([...criticalPathCaseIds].toSorted());
+});

--- a/tests/cli/options.test.ts
+++ b/tests/cli/options.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { criticalPathCaseIds } from "@/cases/critical-path.ts";
 import { evalCases } from "@/cases/index.ts";
 import { parseCliOptions, selectEvalCases } from "@/cli/run.ts";
 
@@ -34,5 +35,42 @@ test("parseCliOptions reads tool config and compare flags", () => {
 test("parseCliOptions rejects duplicate compare ids", () => {
   expect(() => parseCliOptions(["--compare", "baseline,baseline"])).toThrow(
     "must be unique",
+  );
+});
+
+test("parseCliOptions reads compare-models flag", () => {
+  const cliOptions = parseCliOptions([
+    "--compare-models",
+    "gemini-3.1-flash-lite,gemini-3.1-pro",
+  ]);
+
+  expect(cliOptions.compareModelIds).toEqual([
+    "gemini-3.1-flash-lite",
+    "gemini-3.1-pro",
+  ]);
+});
+
+test("parseCliOptions reads replay flag", () => {
+  const cliOptions = parseCliOptions(["--replay", "results/latest.json"]);
+  expect(cliOptions.replayPath).toBe("results/latest.json");
+});
+
+test("parseCliOptions rejects compare and compare-models together", () => {
+  expect(() =>
+    parseCliOptions([
+      "--compare",
+      "baseline,strict-eval",
+      "--compare-models",
+      "gemini-a,gemini-b",
+    ]),
+  ).toThrow("not both");
+});
+
+test("parseCliOptions critical-path filter selects ship-gate cases", () => {
+  const cliOptions = parseCliOptions(["--critical-path"]);
+  const selectedEvalCases = selectEvalCases(evalCases, cliOptions);
+
+  expect(selectedEvalCases.map((evalCase) => evalCase.id).toSorted()).toEqual(
+    [...criticalPathCaseIds].toSorted(),
   );
 });

--- a/tests/replay/run-replay.test.ts
+++ b/tests/replay/run-replay.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { replayEvalCase, runReplayFile } from "@/replay/run-replay.ts";
+import type { EvalReplayDocument } from "@/types.ts";
+
+test("replayEvalCase applies assertions without calling Gemini", () => {
+  const replayDocument: EvalReplayDocument = {
+    caseId: "search-miss-unknown-label",
+    toolConfigId: "baseline",
+    output: "No matching work was found in the graph.",
+    runCompleted: true,
+    trajectory: [
+      {
+        stepIndex: 0,
+        toolName: "searchWorld",
+        args: { query: "z9Qk4WnP" },
+        result: { success: true, results: [] },
+      },
+    ],
+  };
+
+  const replayResult = replayEvalCase(replayDocument);
+  expect(replayResult.success).toBe(true);
+  expect(
+    replayResult.assertions.find(
+      (assertion) => assertion.name === "states-not-found",
+    )?.pass,
+  ).toBe(true);
+});
+
+test("runReplayFile loads committed replay documents", async () => {
+  const replayPath = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "replays",
+    "search-miss-unknown-label.replay.json",
+  );
+  const replaySuiteResult = await runReplayFile(replayPath);
+  expect(replaySuiteResult.success).toBe(true);
+  expect(replaySuiteResult.results).toHaveLength(1);
+});

--- a/tests/runner/run-parallel-tasks.test.ts
+++ b/tests/runner/run-parallel-tasks.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { runParallelTasks } from "@/runner/run-parallel-tasks.ts";
+
+test("runParallelTasks preserves result order", async () => {
+  const results = await runParallelTasks(
+    [0, 1, 2, 3, 4].map((taskIndex) => async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, (4 - taskIndex) * 5);
+      });
+      return taskIndex;
+    }),
+    2,
+  );
+
+  expect(results).toEqual([0, 1, 2, 3, 4]);
+});

--- a/tests/scripts/render-eval-report.test.ts
+++ b/tests/scripts/render-eval-report.test.ts
@@ -83,12 +83,31 @@ test("renderEvalReport falls back to latest suite results", () => {
         metadata: {
           providerId: "google",
           modelId: "gemini-3.1-flash-lite",
-          stepCount: 1,
+          stepCount: 2,
           latencyMs: 10,
-          trajectory: [],
+          trajectory: [
+            {
+              stepIndex: 0,
+              toolName: "searchWorld",
+              args: { query: "example" },
+              result: { success: true, results: [] },
+            },
+            {
+              stepIndex: 1,
+              toolName: "executeSparql",
+              args: { query: "SELECT ?house WHERE { ?s ?p ?house }" },
+              result: { success: true, bindings: [] },
+            },
+          ],
         },
-        assertions: [{ name: "final-answer", pass: false }],
-        toolSequence: ["searchWorld"],
+        assertions: [
+          {
+            name: "final-answer",
+            pass: false,
+            message: "Expected output to contain literal",
+          },
+        ],
+        toolSequence: ["searchWorld", "executeSparql"],
       },
     ],
   };
@@ -100,6 +119,9 @@ test("renderEvalReport falls back to latest suite results", () => {
 
   expect(report).toContain("single-trial-failure<br>Single trial failure");
   expect(report).toContain("## Final-trial failures");
-  expect(report).toContain("searchWorld");
+  expect(report).toContain("searchWorld -> executeSparql");
+  expect(report).toContain("SPARQL excerpt");
+  expect(report).toContain("SELECT ?house");
+  expect(report).toContain("Expected output to contain literal");
   expect(report).toContain("model output with \\| pipe");
 });


### PR DESCRIPTION
## Summary
- Add ship-gate critical path IDs and `--critical-path` shorthand filter.
- Add PR live eval workflow (secret-gated) for critical-path slice.
- Add `--compare-models` with bounded parallelism for quick capability checks.
- Add offline `--replay` for assertion-only replay of saved traces and committed repro docs.
- Tighten miss-path discipline with an explicit refusal assertion and shared refusal phrases.
- Enrich CI report output with failed assertion messages and a SPARQL args excerpt.

## Test plan
- [x] `bun run ci`
- [ ] Optional: run `bun run evals --critical-path --trials 3 --min-pass-rate 1` with API key
- [ ] Optional: run `bun run evals --compare-models gemini-3.1-flash-lite,gemini-3.1-pro --critical-path`